### PR TITLE
Rename qi template to qi-tutorial

### DIFF
--- a/templates/qi-tutorial
+++ b/templates/qi-tutorial
@@ -1,4 +1,4 @@
-(name qi
+(name qi-tutorial
  repo "countvajhula/qi-tutorial"
  from github
  desc "An interactive tutorial for the Qi language.")


### PR DESCRIPTION
Apologies for making so many pull requests. Looks like I renamed the repo but not the template in my last PR. This renames the template as well.
