### PR TITLE
Add monolithic and lib-test-doc project templates

### DIFF
--- a/templates/library
+++ b/templates/library
@@ -1,4 +1,4 @@
-(name project
+(name library
  repo "countvajhula/racket-library"
  from github
  desc "A project template for a Racket library, using the lib/test/doc organization scheme. This template employs many best practices including automated testing, coverage reporting, and Makefile-driven workflows.")

--- a/templates/library
+++ b/templates/library
@@ -1,0 +1,4 @@
+(name project
+ repo "countvajhula/racket-library"
+ from github
+ desc "A project template for a Racket library, using the lib/test/doc organization scheme. This template employs many best practices including automated testing, coverage reporting, and Makefile-driven workflows.")

--- a/templates/project
+++ b/templates/project
@@ -1,0 +1,4 @@
+(name project
+ repo "countvajhula/racket-project"
+ from github
+ desc "A project template for a single-collection Racket package. It employs many best practices including automated testing, coverage reporting, and Makefile-driven workflows.")


### PR DESCRIPTION
This adds two project templates:

1. [project](https://github.com/countvajhula/racket-project) -- A single-collection package
2. [library](https://github.com/countvajhula/racket-library) -- A library using the lib/test/doc scheme (i.e. three packages)

Both of these have similar CI tooling and other infrastructure (e.g. Makefile, GitHub Actions workflows, coverage).

The README explains how to use the template and set up the different features.

These templates also include a notion of "rendering" -- since there are many places in the repo where the same information needs to be populated, there is an included `render-template.sh` shell script. This will ask two questions: (1) the project name, and (2) the user's GitHub handle, and then populate all of the different files / rename relevant files in the repo, to match these.

I've tested both of these templates locally by just copying the folders to temporary paths and running the `render-template` script, giving the project a one-off name, and trying each of the make targets (starting with `make install` to install the project). Running just `make` shows a menu of all available options, e.g. `make test`, `make build-docs`, etc.

#### Possible Future Improvements

Just noting these for future consideration:

- Since the rendering script is a Bash script, I assume it will not work on Windows -- it would be nice to have a platform-independent version of this. The script is a simple search-and-replace -- ideally it would be made more general in the future, e.g. walking the directory tree recursively and making the regex replacements in all files with matching extensions (e.g. `.rkt`, `.rst`, `.txt`, `.scrbl`) -- or there might be existing tools that do this kind of thing.

- Another thing is, the idea of "rendering" is not really specific to these templates -- in fact all templates would probably benefit from this feature, to help users avoid manual search-and-replace, and ideally it should be triggered in the setup process that happens with `raco new <template>` without requiring a separate step like `render-template`.

- There are many possible options that different Racket projects might need. The ones in these templates would apply to many, maybe most projects. But there are probably dozens of options here that may be desirable in different cases, and some of the options included in these templates may not be used by all projects. To address this, in addition to the "rendering" step, it could be useful to also have a "customization" step, which could be a separate script that actually builds the final product on the user's destination folder. That is, in addition to templates that come fully prepared with just placeholder variables that are filled in, some templates could take advantage of a customization step which could take the user's preferences into account. E.g. for the project templates, it could be something like, "Are you interested in running profilers for your library code?" "Are you interested in using a continuous benchmarking service to track performance changes over time?" "Would you like to report test coverage on your project README?" Etc. And with all of these options, the customizer could generate the result at the end that includes only what the user selected instead of extra stuff they may not need, or insufficient things by erring on the side of being conservative.
